### PR TITLE
(Semi-)Working pool for BSHA3

### DIFF
--- a/lib/merkleTree.js
+++ b/lib/merkleTree.js
@@ -10,7 +10,7 @@ var MerkleTree = module.exports = function MerkleTree(data){
 
     function merkleJoin(h1, h2){
         var joined = Buffer.concat([h1, h2]);
-        var dhashed = util.sha3d(joined);
+        var dhashed = util.sha256d(joined);
         return dhashed;
     }
 
@@ -51,7 +51,7 @@ var MerkleTree = module.exports = function MerkleTree(data){
 MerkleTree.prototype = {
     withFirst: function(f){
         this.steps.forEach(function(s){
-            f = util.sha3d(Buffer.concat([f, s]));
+            f = util.sha256d(Buffer.concat([f, s]));
         });
         return f;
     }

--- a/lib/util.js
+++ b/lib/util.js
@@ -37,7 +37,7 @@ exports.sha256d = function(buffer){
 exports.sha3 = function(buffer){
     var hash1 = sha3_256.create();
     hash1.update(buffer);
-    return hash1.hex();
+    return hash1.digest();
 };
 
 exports.sha3d = function(buffer){

--- a/lib/util.js
+++ b/lib/util.js
@@ -287,8 +287,12 @@ exports.addressToScript = function(addr){
     }
 
     var pubkey = decoded.slice(1,-4);
-
-    return Buffer.concat([new Buffer([0x76, 0xa9, 0x14]), pubkey, new Buffer([0x88, 0xac])]);
+    if (decoded[0] == 88) { // BSHA3 P2SH
+        return Buffer.concat([new Buffer([0xa9, 0x14]), pubkey, new Buffer([0x87])]);
+    }
+    else { // P2PK
+        return Buffer.concat([new Buffer([0x76, 0xa9, 0x14]), pubkey, new Buffer([0x88, 0xac])]);
+    }
 };
 
 


### PR DESCRIPTION
* Although it calculates the hashes of the leaves using sha3d, BSHA3 performs the reduction step of merkle root calculation using [SHA256d](https://github.com/BSHA3/bsha3/blob/master/src/consensus/merkle.cpp#L57).
* sha3d function should return bytes, not hex string.
* Properly handle P2SH addresses in coinbase transaction (88 for BSHA3)